### PR TITLE
templates update

### DIFF
--- a/leuven.py
+++ b/leuven.py
@@ -1,4 +1,4 @@
-def build_fancy_dict(logical_path, callback):
+def build_fancy_dict(callback, logical_path):
 
     the_metadata = {'leuven': 'fancy'}
 

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -105,13 +105,11 @@ def metadata_templates_data_object_gather(rule_args, callback, rei):
             except Exception as e:
                 callback.writeLine('serverLog', '{}'.format(type(e)))
         elif thetype == 'irods':
-            # get length of iRODS full logical path
-            ret = callback.msiObjStat(schema, irods_types.RodsObjStat())
-            objstat = ret['arguments'][1]
             # get schema contents from iRODS full logical path
             ret = callback.msiDataObjOpen(schema, 0)
             fd = ret['arguments'][1] # iRODS file descriptor
-            ret = callback.msiDataObjRead(fd, objstat.objSize, irods_types.BytesBuf())
+            maxsize = (1<<31)-1 # maximum size - only contents of filesize will actually be read
+            ret = callback.msiDataObjRead(fd, maxsize, irods_types.BytesBuf())
             buf = ret['arguments'][2] # bytesbuf
             byteslist = buf.get_bytes() # schema contents as list of bytes as integers
             callback.msiDataObjClose(fd, 0)

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -11,6 +11,7 @@ import jsonschema
 import requests
 
 from genquery import *
+import irods_types
 
 MT_NAMESPACE = 'irods::metadata_templates'
 
@@ -103,6 +104,21 @@ def metadata_templates_data_object_gather(rule_args, callback, rei):
                 schemas.append(j)
             except Exception as e:
                 callback.writeLine('serverLog', '{}'.format(type(e)))
+        elif thetype == 'irods':
+            # get length of iRODS full logical path
+            ret = callback.msiObjStat(schema, irods_types.RodsObjStat())
+            objstat = ret['arguments'][1]
+            # get schema contents from iRODS full logical path
+            ret = callback.msiDataObjOpen(schema, 0)
+            fd = ret['arguments'][1] # iRODS file descriptor
+            ret = callback.msiDataObjRead(fd, objstat.objSize, irods_types.BytesBuf())
+            buf = ret['arguments'][2] # bytesbuf
+            byteslist = buf.get_bytes() # schema contents as list of bytes as integers
+            callback.msiDataObjClose(fd, 0)
+            # convert to json object
+            j = json.loads(bytes(byteslist).decode("utf-8"))
+            # add to schemas array
+            schemas.append(j)
         else:
             callback.writeLine('serverLog', 'Type [{}] Not Supported By Metadata Templates'.format(thetype))
 
@@ -157,6 +173,21 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
                 schemas.append(j)
             except Exception as e:
                 callback.writeLine('serverLog', '{}'.format(type(e)))
+        elif thetype == 'irods':
+            # get length of iRODS full logical path
+            ret = callback.msiObjStat(schema, irods_types.RodsObjStat())
+            objstat = ret['arguments'][1]
+            # get schema contents from iRODS full logical path
+            ret = callback.msiDataObjOpen(schema, 0)
+            fd = ret['arguments'][1] # iRODS file descriptor
+            ret = callback.msiDataObjRead(fd, objstat.objSize, irods_types.BytesBuf())
+            buf = ret['arguments'][2] # bytesbuf
+            byteslist = buf.get_bytes() # schema contents as list of bytes as integers
+            callback.msiDataObjClose(fd, 0)
+            # convert to json object
+            j = json.loads(bytes(byteslist).decode("utf-8"))
+            # add to schemas array
+            schemas.append(j)
         else:
             callback.writeLine('serverLog', 'Type [{}] Not Supported By Metadata Templates'.format(thetype))
 

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -260,7 +260,7 @@ def _mt_validate(callback, json_to_validate, schemas_string):
     return []
 
 
-def _mt_get_avus(logical_path, callback):
+def _mt_get_avus(callback, logical_path):
     # Naive implementation to get AVUs for a logical path
     # - Will stomp on identical attributes with multiple values
     # - Will stomp on identical a/v combinations with different units
@@ -299,14 +299,14 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
             modulename, funcname = avu_builder_function.split('.', 1)
             module = __import__(modulename)
             func = getattr(module, funcname)
-            the_metadata = func(logical_path, callback)
+            the_metadata = func(callback, logical_path)
         except (ModuleNotFoundError, AttributeError, ValueError):
 #            callback.writeLine('serverLog', 'except triggered, function [{0}] not found'.format(avu_builder_function))
             errors = ['function [{0}] not found'.format(avu_builder_function)]
     else:
         # no function defined, call naive implementation
 #        callback.writeLine('serverLog', 'function name empty, executing _mt_get_avus [{0}]'.format(logical_path))
-        the_metadata = _mt_get_avus(logical_path, callback)
+        the_metadata = _mt_get_avus(callback, logical_path)
 #        callback.writeLine('serverLog', 'just after _mt_get_avus - the_metadata [{0}]'.format(the_metadata))
 
 #    callback.writeLine('serverLog', 'the_metadata [{0}]'.format(the_metadata))

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -6,6 +6,30 @@
 #
 #################################
 
+"""iRODS Metadata Templates
+
+This module assumes a metadata template is a valid JSON-Schema document.
+
+This module provides standardized metadata template functionality for an iRODS Server:
+- attach
+- detach
+- gather
+- validate
+
+This module does not provide functionality to manage JSON-Schema documents themselves.
+
+Metadata templates can be located at:
+- an iRODS logical path
+- a local filesystem
+- a public URL
+
+Metadata templates can be attached, or associated, with iRODS Data Objects and Collections via AVUs.
+
+A Data Object and Collections of Data Objects can be validated against any associated templates.
+
+A request for validation will return any validation errors found by the JSON-Schema validator.
+"""
+
 import json
 import jsonschema
 import requests

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -225,7 +225,7 @@ def metadata_templates_collection_validate(rule_args, callback, rei):
     # - Return result (OK or failure/explanation)
 
     logical_path = rule_args[0]
-    schemas = rule_args[1]
+    schemas_string = rule_args[1]
     avu_builder_function = rule_args[2]
     recursive = rule_args[3]
 
@@ -240,7 +240,7 @@ def metadata_templates_collection_validate(rule_args, callback, rei):
     # loop through data_objects, validate each
     callback.writeLine('serverLog', repr(data_objects))
     for data_object_path in data_objects:
-        ret = callback.metadata_templates_data_object_validate(data_object_path, schemas, avu_builder_function, '')
+        ret = callback.metadata_templates_data_object_validate(data_object_path, schemas_string, avu_builder_function, '')
         errors = ret['arguments'][3]
         callback.writeLine('serverLog', 'metadata_templates_data_object_validate_ERRORS: [{}]'.format(errors))
         # if anything failed, log and error out

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -156,9 +156,9 @@ def mt_validate(callback, json_to_validate, schemas_string):
     # if anything failed, log the errors
     if errors:
         callback.writeLine('serverLog', 'VALIDATE_ERRORS: {}'.format(repr(errors)))
-        return repr(errors)
+        return errors
     # success
-    return ""
+    return []
 
 
 def mt_get_avus(logical_path, callback):
@@ -216,7 +216,7 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
         errors = mt_validate(callback, the_metadata, schemas_string)
 
 #    callback.writeLine('serverLog', 'AFTER_VALIDATION_ERRORS: [{}]'.format(errors))
-    rule_args[3] = errors
+    rule_args[3] = repr(errors)
 
 
 def metadata_templates_collection_validate(rule_args, callback, rei):

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -15,7 +15,7 @@ import irods_types
 
 MT_NAMESPACE = 'irods::metadata_templates'
 
-def mt_build_json_input(entity_name, entity_type, operation, value, units):
+def _mt_build_json_input(entity_name, entity_type, operation, value, units):
     json_input = {
         "entity_name": entity_name,
         "entity_type": entity_type,
@@ -31,16 +31,16 @@ def mt_build_json_input(entity_name, entity_type, operation, value, units):
     return json_input
 
 
-def mt_attach(callback, entity_name, entity_type, value, units):
+def _mt_attach(callback, entity_name, entity_type, value, units):
     # build JSON input for atomic payload
-    json_input = mt_build_json_input(entity_name, entity_type, 'add', value, units)
+    json_input = _mt_build_json_input(entity_name, entity_type, 'add', value, units)
     # call atomic, assume any errors will show up in the serverLog
     callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), '')
 
 
-def mt_detach(callback, entity_name, entity_type, value, units):
+def _mt_detach(callback, entity_name, entity_type, value, units):
     # build JSON input for atomic payload
-    json_input = mt_build_json_input(entity_name, entity_type, 'remove', value, units)
+    json_input = _mt_build_json_input(entity_name, entity_type, 'remove', value, units)
     # call atomic, assume any errors will show up in the serverLog
     callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), '')
 
@@ -50,7 +50,7 @@ def metadata_templates_data_object_attach(rule_args, callback, rei):
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
-    result = mt_attach(callback, logical_path, 'data_object', schema, type)
+    result = _mt_attach(callback, logical_path, 'data_object', schema, type)
 
 
 def metadata_templates_collection_attach(rule_args, callback, rei):
@@ -58,7 +58,7 @@ def metadata_templates_collection_attach(rule_args, callback, rei):
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
-    result = mt_attach(callback, logical_path, 'collection', schema, type)
+    result = _mt_attach(callback, logical_path, 'collection', schema, type)
 
 
 def metadata_templates_data_object_detach(rule_args, callback, rei):
@@ -66,7 +66,7 @@ def metadata_templates_data_object_detach(rule_args, callback, rei):
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
-    result = mt_detach(callback, logical_path, 'data_object', schema, type)
+    result = _mt_detach(callback, logical_path, 'data_object', schema, type)
 
 
 def metadata_templates_collection_detach(rule_args, callback, rei):
@@ -74,7 +74,7 @@ def metadata_templates_collection_detach(rule_args, callback, rei):
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
-    result = mt_detach(callback, logical_path, 'collection', schema, type)
+    result = _mt_detach(callback, logical_path, 'collection', schema, type)
 
 
 def metadata_templates_data_object_gather(rule_args, callback, rei):
@@ -240,7 +240,7 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
     rule_args[2] = json.dumps(schemas)
 
 
-def mt_validate(callback, json_to_validate, schemas_string):
+def _mt_validate(callback, json_to_validate, schemas_string):
     # run json_to_validate through each schema, collecting any errors
     errors = []
 #    callback.writeLine('serverLog', 'TYPE: ::{}:: SCHEMAS: ::{}::'.format(type(schemas_string), schemas_string))
@@ -260,14 +260,14 @@ def mt_validate(callback, json_to_validate, schemas_string):
     return []
 
 
-def mt_get_avus(logical_path, callback):
+def _mt_get_avus(logical_path, callback):
     # Naive implementation to get AVUs for a logical path
     # - Will stomp on identical attributes with multiple values
     # - Will stomp on identical a/v combinations with different units
 
     # get AVUs
     collection_name, data_name = logical_path.rsplit("/", 1)
-#    callback.writeLine('serverLog', 'mt_get_avus - collection_name [{0}] data_name [{1}]'.format(collection_name, data_name))
+#    callback.writeLine('serverLog', '_mt_get_avus - collection_name [{0}] data_name [{1}]'.format(collection_name, data_name))
     the_metadata = {}
     for a, v in Query(callback,
                         "META_DATA_ATTR_NAME, META_DATA_ATTR_VALUE",
@@ -276,7 +276,7 @@ def mt_get_avus(logical_path, callback):
 #        callback.writeLine('serverLog', 'in avu loop... the_metadata [{0}]'.format(the_metadata))
 
     # return dict
-#    callback.writeLine('serverLog', 'mt_get_avus - the_metadata [{0}]'.format(the_metadata))
+#    callback.writeLine('serverLog', '_mt_get_avus - the_metadata [{0}]'.format(the_metadata))
     return the_metadata
 
 def metadata_templates_data_object_validate(rule_args, callback, rei):
@@ -305,15 +305,15 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
             errors = ['function [{0}] not found'.format(avu_builder_function)]
     else:
         # no function defined, call naive implementation
-#        callback.writeLine('serverLog', 'function name empty, executing mt_get_avus [{0}]'.format(logical_path))
-        the_metadata = mt_get_avus(logical_path, callback)
-#        callback.writeLine('serverLog', 'just after mt_get_avus - the_metadata [{0}]'.format(the_metadata))
+#        callback.writeLine('serverLog', 'function name empty, executing _mt_get_avus [{0}]'.format(logical_path))
+        the_metadata = _mt_get_avus(logical_path, callback)
+#        callback.writeLine('serverLog', 'just after _mt_get_avus - the_metadata [{0}]'.format(the_metadata))
 
 #    callback.writeLine('serverLog', 'the_metadata [{0}]'.format(the_metadata))
     if not errors:
         # no exception occurred
         # validate, catch validation errors
-        errors = mt_validate(callback, the_metadata, schemas_string)
+        errors = _mt_validate(callback, the_metadata, schemas_string)
 
 #    callback.writeLine('serverLog', 'AFTER_VALIDATION_ERRORS: [{}]'.format(errors))
     if errors:

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -192,12 +192,8 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
 
     the_metadata = {}
     errors = []
-    if avu_builder_function in ['', '""']:
-        # no function defined, call naive implementation
-#        callback.writeLine('serverLog', 'function name empty, executing mt_get_avus [{0}]'.format(logical_path))
-        the_metadata = mt_get_avus(logical_path, callback)
-#        callback.writeLine('serverLog', 'just after mt_get_avus - the_metadata [{0}]'.format(the_metadata))
-    else:
+    if avu_builder_function:
+        # function defined
         try:
             # import and execute the defined function
 #            callback.writeLine('serverLog', 'trying to load module [{0}]'.format(avu_builder_function))
@@ -208,6 +204,11 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
         except (ModuleNotFoundError, AttributeError, ValueError):
 #            callback.writeLine('serverLog', 'except triggered, function [{0}] not found'.format(avu_builder_function))
             errors = ['function [{0}] not found'.format(avu_builder_function)]
+    else:
+        # no function defined, call naive implementation
+#        callback.writeLine('serverLog', 'function name empty, executing mt_get_avus [{0}]'.format(logical_path))
+        the_metadata = mt_get_avus(logical_path, callback)
+#        callback.writeLine('serverLog', 'just after mt_get_avus - the_metadata [{0}]'.format(the_metadata))
 
 #    callback.writeLine('serverLog', 'the_metadata [{0}]'.format(the_metadata))
     if not errors:

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -33,19 +33,15 @@ def mt_build_json_input(entity_name, entity_type, operation, value, units):
 def mt_attach(callback, entity_name, entity_type, value, units):
     # build JSON input for atomic payload
     json_input = mt_build_json_input(entity_name, entity_type, 'add', value, units)
-    # call atomic
-    result = callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), "")
-    # check for errors
-    ### something something ... result['arguments'][0]
+    # call atomic, assume any errors will show up in the serverLog
+    callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), '')
 
 
 def mt_detach(callback, entity_name, entity_type, value, units):
     # build JSON input for atomic payload
     json_input = mt_build_json_input(entity_name, entity_type, 'remove', value, units)
-    # call atomic
-    result = callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), "")
-    # check for errors
-    ### something something ... result['arguments'][0]
+    # call atomic, assume any errors will show up in the serverLog
+    callback.msi_atomic_apply_metadata_operations(json.dumps(json_input), '')
 
 
 def metadata_templates_data_object_attach(rule_args, callback, rei):

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -216,7 +216,8 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
         errors = mt_validate(callback, the_metadata, schemas_string)
 
 #    callback.writeLine('serverLog', 'AFTER_VALIDATION_ERRORS: [{}]'.format(errors))
-    rule_args[3] = repr(errors)
+    if errors:
+        rule_args[3] = repr(errors)
 
 
 def metadata_templates_collection_validate(rule_args, callback, rei):

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -16,6 +16,17 @@ import irods_types
 MT_NAMESPACE = 'irods::metadata_templates'
 
 def _mt_build_json_input(entity_name, entity_type, operation, value, units):
+    """Utility function to build a JSON input stanza for msi_atomic_apply_metadata_operations()
+
+    Inputs:
+    - entity_name - string of absolute path of data object or collection
+    - entity_type - string of 'data_object' or 'collection'
+    - operation - string of 'add' or 'remove'
+    - value - string of AVU value
+    - units - string of AVU units
+    Returns:
+    - JSON-string - ready for use by msi_atomic_apply_metadata_operations()
+    """
     json_input = {
         "entity_name": entity_name,
         "entity_type": entity_type,
@@ -32,6 +43,17 @@ def _mt_build_json_input(entity_name, entity_type, operation, value, units):
 
 
 def _mt_attach(callback, entity_name, entity_type, value, units):
+    """Utility function to attach a metadata template to a data object or collection
+
+    Inputs:
+    - callback - callback handle to iRODS Rule Engine Framework
+    - entity_name - string of absolute path of data object or collection
+    - entity_type - string of 'data_object' or 'collection'
+    - value - string of AVU value
+    - units - string of AVU units
+    Returns:
+    - nothing
+    """
     # build JSON input for atomic payload
     json_input = _mt_build_json_input(entity_name, entity_type, 'add', value, units)
     # call atomic, assume any errors will show up in the serverLog
@@ -39,6 +61,17 @@ def _mt_attach(callback, entity_name, entity_type, value, units):
 
 
 def _mt_detach(callback, entity_name, entity_type, value, units):
+    """Utility function to detach a metadata template from a data object or collection
+
+    Inputs:
+    - callback - callback handle to iRODS Rule Engine Framework
+    - entity_name - string of absolute path of data object or collection
+    - entity_type - string of 'data_object' or 'collection'
+    - value - string of AVU value
+    - units - string of AVU units
+    Returns:
+    - nothing
+    """
     # build JSON input for atomic payload
     json_input = _mt_build_json_input(entity_name, entity_type, 'remove', value, units)
     # call atomic, assume any errors will show up in the serverLog
@@ -46,7 +79,15 @@ def _mt_detach(callback, entity_name, entity_type, value, units):
 
 
 def metadata_templates_data_object_attach(rule_args, callback, rei):
-    # Attach (logical_path, schema, type)
+    """Attaches a metadata template to a data object
+
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schema - location of schema
+    - type - type of schema location ['irods', 'local', 'url']
+    Output:
+    - None
+    """
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
@@ -54,7 +95,15 @@ def metadata_templates_data_object_attach(rule_args, callback, rei):
 
 
 def metadata_templates_collection_attach(rule_args, callback, rei):
-    # Attach (logical_path, schema, type)
+    """Attaches a metadata template to a collection
+
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schema - location of schema
+    - type - type of schema location ['irods', 'local', 'url']
+    Output:
+    - None
+    """
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
@@ -62,7 +111,15 @@ def metadata_templates_collection_attach(rule_args, callback, rei):
 
 
 def metadata_templates_data_object_detach(rule_args, callback, rei):
-    # Detach (logical_path, schema, type)
+    """Detaches a metadata template from a data object
+
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schema - location of schema
+    - type - type of schema location ['irods', 'local', 'url']
+    Output:
+    - None
+    """
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
@@ -70,7 +127,15 @@ def metadata_templates_data_object_detach(rule_args, callback, rei):
 
 
 def metadata_templates_collection_detach(rule_args, callback, rei):
-    # Detach (logical_path, schema, type)
+    """Detaches a metadata template from a collection
+
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schema - location of schema
+    - type - type of schema location ['irods', 'local', 'url']
+    Output:
+    - None
+    """
     logical_path = rule_args[0]
     schema = rule_args[1]
     type = rule_args[2]
@@ -78,10 +143,14 @@ def metadata_templates_collection_detach(rule_args, callback, rei):
 
 
 def metadata_templates_data_object_gather(rule_args, callback, rei):
-    # Export/Collapse/Rasterize/Gather/Dump (logical_path, recursive, schemas_string)
-    # - Find all associated schemas
-    # - Recursive gathers schemas on all parents up to root
+    """Gathers all schemas associated with a data object
 
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - recursive - whether to gather schemas on all parents up to root [0=no, 1=yes]
+    Output:
+    - schemas_string - JSON-string of array containing all collected schemas
+    """
     logical_path = rule_args[0]
     recursive = rule_args[1]
 
@@ -148,10 +217,14 @@ def metadata_templates_data_object_gather(rule_args, callback, rei):
 
 
 def metadata_templates_collection_gather(rule_args, callback, rei):
-    # Export/Collapse/Rasterize/Gather/Dump (logical_path, recursive, schemas_string)
-    # - Find all associated schemas
-    # - Recursive gathers schemas on all parents up to root
+    """Gathers all schemas associated with a collection
 
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - recursive - whether to gather schemas on all parents up to root [0=no, 1=yes]
+    Output:
+    - schemas_string - JSON-string of array containing all collected schemas
+    """
     logical_path = rule_args[0]
     recursive = rule_args[1]
 
@@ -241,7 +314,14 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
 
 
 def _mt_validate(callback, json_to_validate, schemas_string):
-    # run json_to_validate through each schema, collecting any errors
+    """Utility function to validate the passed JSON through each passed schema
+
+    Inputs:
+    - json_to_validate - JSON-string representing AVUs to be validated
+    - schemas_string - JSON-string of array of schemas to be used for validation
+    Returns:
+    - errors - list of accumulated schema validation errors
+    """
     errors = []
 #    callback.writeLine('serverLog', 'TYPE: ::{}:: SCHEMAS: ::{}::'.format(type(schemas_string), schemas_string))
     schemas = json.loads(schemas_string)
@@ -261,10 +341,16 @@ def _mt_validate(callback, json_to_validate, schemas_string):
 
 
 def _mt_get_avus(callback, logical_path):
-    # Naive implementation to get AVUs for a logical path
-    # - Will stomp on identical attributes with multiple values
-    # - Will stomp on identical a/v combinations with different units
+    """Utility function to naively get AVUs for a logical path
 
+    Inputs:
+    - callback - callback handle to iRODS Rule Engine Framework
+    - logical_path - absolute iRODS logical path
+    Returns:
+    - the_metadata - python dict containing the naive AVU-to-JSON conversion
+    Side Effects:
+    - This function will stomp AVUs with identical attributes and multiple values
+    """
     # get AVUs
     collection_name, data_name = logical_path.rsplit("/", 1)
 #    callback.writeLine('serverLog', '_mt_get_avus - collection_name [{0}] data_name [{1}]'.format(collection_name, data_name))
@@ -280,11 +366,15 @@ def _mt_get_avus(callback, logical_path):
     return the_metadata
 
 def metadata_templates_data_object_validate(rule_args, callback, rei):
-    # Validate data object (logical_path, schemas_string, avu_builder_function, errors)
-    # - Get and build json payload with all current AVUs
-    # - Run payload and schemas through validator
-    # - Return result (OK or failure/explanation)
+    """Validates a data object's metadata against a set of schemas
 
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schemas_string - JSON-string of array of schemas
+    - avu_builder_function - dotted name of custom module.function for AVU-to-JSON conversion
+    Output:
+    - errors - string of list of any accumulated validation errors
+    """
     logical_path = rule_args[0]
     schemas_string = rule_args[1]
     avu_builder_function = rule_args[2]
@@ -321,16 +411,20 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
 
 
 def metadata_templates_collection_validate(rule_args, callback, rei):
-    # Validate collection (logical_path, schemas_string, avu_builder_function, errors)
-    # - Loop through data objects, validate each
-    # - Return result (OK or failure/explanation)
+    """Validates the metadata of a collection's data objects against a set of schemas
 
+    Inputs:
+    - logical_path - absolute iRODS logical path
+    - schemas_string - JSON-string of array of schemas
+    - avu_builder_function - dotted name of custom module.function for AVU-to-JSON conversion
+    Output:
+    - errors - string of list of any accumulated validation errors
+    """
     logical_path = rule_args[0]
     schemas_string = rule_args[1]
     avu_builder_function = rule_args[2]
 
     # find all data objects in this collection
-    # TODO: or gather all at once, then validate each object individually (in parallel?)
     data_objects = []
     for coll_name, data_name in Query(callback,
                                 "COLL_NAME, DATA_NAME",

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -133,11 +133,19 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
     logical_path = rule_args[0]
     recursive = rule_args[1]
 
+    # clean the logical path
+    if logical_path == '/':
+        # don't touch it, already the root
+        clean_logical_path = logical_path
+    else:
+        # remove any trailing slash
+        clean_logical_path = logical_path.rstrip('/')
+
     # get all schema locations attached to this collection
     schemas = []
     for schema, thetype in Query(callback,
                         "META_COLL_ATTR_VALUE, META_COLL_ATTR_UNITS",
-                        "COLL_NAME = '{}' and META_COLL_ATTR_NAME = '{}'".format(logical_path, MT_NAMESPACE)):
+                        "COLL_NAME = '{}' and META_COLL_ATTR_NAME = '{}'".format(clean_logical_path, MT_NAMESPACE)):
 #        callback.writeLine('serverLog','{} {}'.format(thetype, schema))
         if thetype == 'url':
             try:
@@ -157,14 +165,13 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
 #    callback.writeLine('serverLog', 'metadata_templates_collection_gather: before recursive flag')
 #    callback.writeLine('serverLog', 'length of schemas [{0}]'.format(len(schemas)))
     if int(recursive):
-        callback.writeLine('serverLog', 'metadata_templates_collection_gather: inside recursive flag [{0}]'.format(logical_path))
+        callback.writeLine('serverLog', 'metadata_templates_collection_gather: inside recursive flag [{0}]'.format(clean_logical_path))
 
-        clean_logical_path = logical_path.rstrip('/')
-        if logical_path.count('/') == 0:
+        if clean_logical_path.count('/') == 0:
             callback.writeLine('serverLog', 'metadata_templates_collection_gather: no forward slashes found, stopping')
-        elif logical_path[0] != '/':
+        elif clean_logical_path[0] != '/':
             callback.writeLine('serverLog', 'metadata_templates_collection_gather: not an absolute path, stopping')
-        elif logical_path  == '/':
+        elif clean_logical_path == '/':
             callback.writeLine('serverLog', 'metadata_templates_collection_gather: found /, complete')
         elif clean_logical_path.count('/') == 1:
             # found the top level zone, call gather on root (/)

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -119,6 +119,14 @@ def metadata_templates_data_object_gather(rule_args, callback, rei):
             j = json.loads(bytes(byteslist).decode("utf-8"))
             # add to schemas array
             schemas.append(j)
+        elif thetype == 'local':
+            # get contents
+            with open(schema, 'r') as f:
+                content = f.read()
+                # convert to json object
+                j = json.loads(content)
+                # add to schemas array
+                schemas.append(j)
         else:
             callback.writeLine('serverLog', 'Type [{}] Not Supported By Metadata Templates'.format(thetype))
 
@@ -188,6 +196,14 @@ def metadata_templates_collection_gather(rule_args, callback, rei):
             j = json.loads(bytes(byteslist).decode("utf-8"))
             # add to schemas array
             schemas.append(j)
+        elif thetype == 'local':
+            # get contents
+            with open(schema, 'r') as f:
+                content = f.read()
+                # convert to json object
+                j = json.loads(content)
+                # add to schemas array
+                schemas.append(j)
         else:
             callback.writeLine('serverLog', 'Type [{}] Not Supported By Metadata Templates'.format(thetype))
 

--- a/metadata_templates.py
+++ b/metadata_templates.py
@@ -197,7 +197,7 @@ def metadata_templates_data_object_validate(rule_args, callback, rei):
         try:
             # import and execute the defined function
 #            callback.writeLine('serverLog', 'trying to load module [{0}]'.format(avu_builder_function))
-            modulename, funcname = avu_builder_function.split('.', 2)
+            modulename, funcname = avu_builder_function.split('.', 1)
             module = __import__(modulename)
             func = getattr(module, funcname)
             the_metadata = func(logical_path, callback)

--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,12 @@
+{
+    "$id": "file:///tmp/sample.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"}
+    },
+    "required": [
+        "name"
+    ]
+}

--- a/test_metadata_templates.bats
+++ b/test_metadata_templates.bats
@@ -30,7 +30,7 @@ teardown () {
     run iadmin rum
 }
 
-@test "data object - attach, gather, detach template" {
+@test "data object - attach, gather, detach template from URL" {
     # main
     run imkdir -p ${LOGICAL_PATH}
     [ $status -eq 0 ]
@@ -162,7 +162,7 @@ teardown () {
     [ $status -eq 0 ]
 }
 
-@test "collection - attach, gather, detach template" {
+@test "collection - attach, gather, detach template from URL" {
     # main
     run imkdir -p ${LOGICAL_PATH}
     [ $status -eq 0 ]

--- a/test_metadata_templates.bats
+++ b/test_metadata_templates.bats
@@ -50,7 +50,7 @@ teardown () {
     # gather and confirm output has parsed JSON
     run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -91,7 +91,7 @@ teardown () {
     # gather and confirm no JSON parsed correctly
     run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -124,7 +124,7 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_data_object_validate('*data_object_path', *schemas, '*avu_function', *rc); \
             writeLine('stdout', *rc)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*data_object_path='${DATA_OBJECT_A}'%*avu_function=leuven.build_fancy_dict%*rc=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*data_object_path='${DATA_OBJECT_A}'%*avu_function=leuven.build_fancy_dict%*rc=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -141,7 +141,7 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_data_object_validate('*data_object_path', *schemas, '*avu_function', *rc); \
             writeLine('stdout', *rc)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*data_object_path='${DATA_OBJECT_A}'%*avu_function=""%*rc=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*data_object_path='${DATA_OBJECT_A}'%*avu_function=%*rc=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -158,7 +158,7 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_data_object_validate('*data_object_path', *schemas, '*avu_function', *rc); \
             writeLine('stdout', *rc)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*data_object_path='${DATA_OBJECT_A}'%*avu_function=""%*rc=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*data_object_path='${DATA_OBJECT_A}'%*avu_function=%*rc=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -175,14 +175,14 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_data_object_validate('*data_object_path', *schemas, '*avu_function', *rc); \
             writeLine('stdout', *rc)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*data_object_path='${DATA_OBJECT_A}'%*avu_function=""%*rc=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*data_object_path='${DATA_OBJECT_A}'%*avu_function=%*rc=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
     echo "output = ${output}"
     [ $status -eq 0 ]
     # validator is happy
-    [[ "${lines[0]}" = "[]" ]]
+    [[ "${lines[0]}" = "" ]]
 
     # cleanup
     run irm -rf ${TEST_COLLECTION}
@@ -220,7 +220,7 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_collection_validate('*logical_path', *schemas, '*avu_function', *recursive, *errors); \
             writeLine('stdout', *errors)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*avu_function=""%*errors=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*avu_function=%*errors=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
@@ -234,14 +234,14 @@ teardown () {
         "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); \
             metadata_templates_collection_validate('*logical_path', *schemas, '*avu_function', *recursive, *errors); \
             writeLine('stdout', *errors)" \
-        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=""%*avu_function=""%*errors=""' \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=%*avu_function=%*errors=' \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     echo $status
     echo "output = ${output}"
     [ $status -eq 0 ]
     # validator is happy
-    [[ "${lines[0]}" = "[]" ]]
+    [[ "${lines[0]}" = "" ]]
 
     # cleanup
     run irm -rf ${TEST_COLLECTION}

--- a/test_metadata_templates.bats
+++ b/test_metadata_templates.bats
@@ -181,8 +181,8 @@ teardown () {
     echo $status
     echo "output = ${output}"
     [ $status -eq 0 ]
-    # validator is happy    
-    [[ "${lines[0]}" = "" ]]
+    # validator is happy
+    [[ "${lines[0]}" = "[]" ]]
 
     # cleanup
     run irm -rf ${TEST_COLLECTION}
@@ -240,8 +240,8 @@ teardown () {
     echo $status
     echo "output = ${output}"
     [ $status -eq 0 ]
-    # validator is happy    
-    [[ "${lines[0]}" = '""' ]]
+    # validator is happy
+    [[ "${lines[0]}" = "[]" ]]
 
     # cleanup
     run irm -rf ${TEST_COLLECTION}

--- a/test_metadata_templates.bats
+++ b/test_metadata_templates.bats
@@ -13,6 +13,7 @@ DATA_OBJECT_B=${LOGICAL_PATH}/b.txt
 
 GOOD_SCHEMA_A=https://raw.githubusercontent.com/fge/sample-json-schemas/master/jsonrpc2.0/jsonrpc-request-2.0.json
 GOOD_SCHEMA_B=https://raw.githubusercontent.com/irods/irods/main/schemas/configuration/v4/plugin.json.in
+GOOD_SCHEMA_IRODS=/tempZone/home/rods/sample.json
 BAD_SCHEMA=https://example.org
 ############
 
@@ -72,6 +73,50 @@ teardown () {
     [ $status -eq 0 ]
 }
 
+@test "data object - attach, gather, detach template from iRODS" {
+    # main
+    run imkdir -p ${LOGICAL_PATH}
+    [ $status -eq 0 ]
+    run itouch ${DATA_OBJECT_A}
+    [ $status -eq 0 ]
+    # attach and confirm AVU
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_data_object_attach('*logical_path', '*schema_location', 'irods')" \
+        '*logical_path='${DATA_OBJECT_A}'%*schema_location='${GOOD_SCHEMA_IRODS} \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    run imeta ls -d ${DATA_OBJECT_A}
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[1]}" =~ "attribute: irods::metadata_templates" ]]
+    [[ "${lines[2]}" =~ "value: ${GOOD_SCHEMA_IRODS}" ]]
+    [[ "${lines[3]}" =~ "units: irods" ]]
+    # gather and confirm output has parsed JSON
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_data_object_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" \
+        '*logical_path='${DATA_OBJECT_A}'%*recursive=0%*schemas=' \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    echo $status
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[0]}" =~ "json-schema.org" ]]
+    # detach and confirm no AVUs
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_data_object_detach('*logical_path', '*schema_location', 'irods')" \
+        '*logical_path='${DATA_OBJECT_A}'%*schema_location='${GOOD_SCHEMA_IRODS} \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    run imeta ls -d ${DATA_OBJECT_A}
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[1]}" = "None" ]]
+    # cleanup
+    run irm -rf ${TEST_COLLECTION}
+    run iadmin rum
+    [ $status -eq 0 ]
+}
+
 @test "collection - attach, gather, detach template" {
     # main
     run imkdir -p ${LOGICAL_PATH}
@@ -104,6 +149,50 @@ teardown () {
     run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
         "metadata_templates_collection_detach('*logical_path', '*schema_location', 'url')" \
         '*logical_path='${LOGICAL_PATH}'%*schema_location='${GOOD_SCHEMA_A} \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    run imeta ls -C ${LOGICAL_PATH}
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[1]}" = "None" ]]
+    # cleanup
+    run irm -rf ${TEST_COLLECTION}
+    run iadmin rum
+    [ $status -eq 0 ]
+}
+
+@test "collection - attach, gather, detach template from iRODS" {
+    # main
+    run imkdir -p ${LOGICAL_PATH}
+    [ $status -eq 0 ]
+    run itouch ${DATA_OBJECT_A}
+    [ $status -eq 0 ]
+    # attach and confirm AVU
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_collection_attach('*logical_path', '*schema_location', 'irods')" \
+        '*logical_path='${LOGICAL_PATH}'%*schema_location='${GOOD_SCHEMA_IRODS} \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    run imeta ls -C ${LOGICAL_PATH}
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[1]}" =~ "attribute: irods::metadata_templates" ]]
+    [[ "${lines[2]}" =~ "value: ${GOOD_SCHEMA_IRODS}" ]]
+    [[ "${lines[3]}" =~ "units: irods" ]]
+    # gather and confirm output has parsed JSON
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" \
+        '*logical_path='${LOGICAL_PATH}'%*recursive=0%*schemas=' \
+        ruleExecOut
+    echo $BATS_RUN_COMMAND
+    echo $status
+    echo "output = ${output}"
+    [ $status -eq 0 ]
+    [[ "${lines[0]}" =~ "json-schema.org" ]]
+    # detach and confirm no AVUs
+    run irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+        "metadata_templates_collection_detach('*logical_path', '*schema_location', 'irods')" \
+        '*logical_path='${LOGICAL_PATH}'%*schema_location='${GOOD_SCHEMA_IRODS} \
         ruleExecOut
     echo $BATS_RUN_COMMAND
     run imeta ls -C ${LOGICAL_PATH}

--- a/usage.md
+++ b/usage.md
@@ -64,17 +64,17 @@ units: notaurl
 # gather, print to stdout
 
 ```
-$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=""' ruleExecOut
+$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); writeLine('stdout', *schemas)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=' ruleExecOut
 ```
 
 # validate data object
 
 ```
-$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_data_object_validate('*data_object_path', *schemas, *avu_function, *rc); writeLine('stdout', *rc)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=""%*data_object_path=/tempZone/home/rods/thedir/a.txt%*avu_function=""%*rc=""' ruleExecOut
+$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_data_object_validate('*data_object_path', *schemas, *avu_function, *rc); writeLine('stdout', *rc)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=%*data_object_path=/tempZone/home/rods/thedir/a.txt%*avu_function=%*rc=' ruleExecOut
 ```
 
 # validate a collection
 
 ```
-$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_collection_validate('*logical_path', *schemas, *avu_function, *recursive, *errors); writeLine('stdout', *errors)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=""%*avu_function=""%*errors=""' ruleExecOut
+$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_collection_validate('*logical_path', *schemas, *avu_function, *recursive, *errors); writeLine('stdout', *errors)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=%*avu_function=%*errors=' ruleExecOut
 ```

--- a/usage.md
+++ b/usage.md
@@ -76,5 +76,5 @@ $ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templ
 # validate a collection
 
 ```
-$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_collection_validate('*logical_path', *schemas, *avu_function, *recursive, *errors); writeLine('stdout', *errors)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=%*avu_function=%*errors=' ruleExecOut
+$ irule -r irods_rule_engine_plugin-irods_rule_language-instance "metadata_templates_collection_gather('*logical_path', '*recursive', *schemas); metadata_templates_collection_validate('*logical_path', *schemas, *avu_function, *errors); writeLine('stdout', *errors)" '*logical_path=/tempZone/home/rods/thedir%*recursive=0%*schemas=%*avu_function=%*errors=' ruleExecOut
 ```


### PR DESCRIPTION
in this pr:
- external module handling for AVU-to-JSON conversion
- schemas on data objects
- recursion walks to the root
- schema location now 'url', 'irods', or 'local'

known todo:
 - handle exceptions in 'irods' and 'local' schema gathering